### PR TITLE
ForbidDynamicProperties: fix the bugs

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -106,4 +106,17 @@
         <exclude-pattern>./tests/Fixtures/*\.php$</exclude-pattern>
     </rule>
 
+
+	<!--
+	#############################################################################
+	SELECTIVE EXCLUSIONS
+	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+	#############################################################################
+	-->
+
+	<!-- The polyfills for the PHP native exceptions can not have a namespace. -->
+	<rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+		<exclude-pattern>/compat/Error\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/compat/Error.php
+++ b/compat/Error.php
@@ -1,0 +1,11 @@
+<?php
+
+if (!class_exists('Error')) {
+
+    /**
+     * Polyfill the PHP 7.0+ native Error class.
+     */
+    class Error extends Exception
+    {
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "autoload": {
         "psr-4": {
             "WpOrg\\DynamicPropertiesUtils\\": "src/"
-        }
+        },
+        "files": ["compat/Error.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/ForbidDynamicProperties.php
+++ b/src/ForbidDynamicProperties.php
@@ -3,57 +3,226 @@
 namespace WpOrg\DynamicPropertiesUtils;
 
 use OutOfBoundsException;
+use ReflectionException;
 use ReflectionProperty;
 
+/**
+ * Trait to forbid the use of dynamic properties, while emulating the PHP native behaviour
+ * for everything else.
+ *
+ * {@internal Property names used within the trait are prefixed with an acronym for the class
+ * to minimize the risk of property naming conflicts with classes _using_ this trait.
+ * Aside from the `__set()` method, the same goes for the methods to minimize the risk
+ * of classes _using_ the trait accidentally overloading any of the methods in the trait.}
+ */
 trait ForbidDynamicProperties
 {
+    /**
+     * Backtrace limit.
+     *
+     * To get all the information we need, we only need three frames of the backtrace:
+     * [0] Will contain the call to the `fdpGetBacktrace()` method.
+     * [1] Will contain the call to the `__set()` method + the class in which the `__set()` is composed in.
+     * [2] Will contain the originating context.
+     *
+     * @var int
+     */
+    private $fdpBacktraceLimit = 3;
+
+    /**
+     * Position in the backtrace of the frame for the call to __set().
+     *
+     * @var int
+     */
+    private $fdpSetFrame = 1;
+
+    /**
+     * Position in the backtrace of the frame containing the information on the context
+     * which triggered the call to __set().
+     *
+     * @var int
+     */
+    private $fdpOriginFrame = 2;
+
+    /**
+     * Reflection instance of the current property or false if not reflection instance could be created.
+     *
+     * @var ReflectionProperty|false
+     */
+    private $fdpReflectionProp;
+
+    /**
+     * Magic method which handles property setting for inaccessible and unset properties,
+     * but forbids setting non-existent properties.
+     *
+     * @param string $name  Property name.
+     * @param mixed  $value The new value for the property.
+     *
+     * @return void
+     *
+     * @throws OutOfBoundsException When an attempt is made to set a dynamic property.
+     */
     public function __set($name, $value)
     {
-        if (!static::propertyExists($name)) {
-            throw new OutOfBoundsException('Dynamic properties are not supported for class ' . static::class . '. Property $' . $name . ' cannot be set.');
+        $this->fdpSetReflectionProp($name);
+
+        if ($this->fdpIsPublicProperty()) {
+            // This is an unset public property, just set it.
+            $this->$name = $value;
+            return;
         }
 
-        if ($this->propertyCanBeAccessed($name)) {
-            $this->$name = $value;
+        $backtrace  = $this->fdpGetBacktrace();
+        $selfParent = $this->fdpGetParentClass($backtrace);
+        $callOrigin = $this->fdpGetCallOrigin($backtrace);
+
+        /*
+         * Handle calls which originate from within the class hierarchy which contains the trait.
+         */
+        if (\is_a($callOrigin, $selfParent, true)) {
+            if ($this->fdpIsProtectedProperty()) {
+                $this->$name = $value;
+                return;
+            }
+
+            // This must be a private property.
+            if (\property_exists($callOrigin, $name)) {
+                if ($callOrigin === $selfParent) {
+                    // This is an unset private property accessible from the current context.
+                    $this->$name = $value;
+                    return;
+                }
+
+                /*
+                 * Property is not accessible from the current context, use Reflection to set the value,
+                 * but make sure the set actually succeeded.
+                 */
+                if ($this->fdpSetInaccessibleProperty($callOrigin, $name, $value) === true) {
+                    return;
+                }
+            }
+        }
+
+        if ($callOrigin !== static::class && \property_exists(static::class, $name) === true) {
+            // This is an inaccessible property in the "outer" class. Emulate the PHP native error.
+            \trigger_error(\sprintf('Cannot access private property %s::$%s', static::class, $name), \E_USER_ERROR);
+            return;
+        }
+
+        // This is an attempt to set a dynamic property.
+        throw new OutOfBoundsException(
+            \sprintf(
+                'Dynamic properties are not supported for class %s. Property $%s cannot be set.',
+                static::class,
+                $name
+            )
+        );
+    }
+
+    /**
+     * Retrieve a ReflectionProperty instance of the current property and store it.
+     *
+     * @param string $propertyName Property name.
+     *
+     * @return void
+     */
+    private function fdpSetReflectionProp($propertyName)
+    {
+        try {
+            $this->fdpReflectionProp = new ReflectionProperty($this, $propertyName);
+        } catch (ReflectionException $e) {
+            $this->fdpReflectionProp = false;
         }
     }
 
-    private function propertyCanBeAccessed($name)
+    /**
+     * Check if the current property is public.
+     *
+     * @return bool
+     */
+    private function fdpIsPublicProperty()
     {
-        if ($this->isPublicProperty($name)) {
-            return true;
+        return $this->fdpReflectionProp !== false && $this->fdpReflectionProp->isPublic();
+    }
+
+    /**
+     * Check if the current property is protected.
+     *
+     * @return bool
+     */
+    private function fdpIsProtectedProperty()
+    {
+        return $this->fdpReflectionProp !== false && $this->fdpReflectionProp->isProtected();
+    }
+
+    /**
+     * Retrieve a limited backtrace of the call triggering the `__set()`.
+     *
+     * @return array[]
+     */
+    private function fdpGetBacktrace()
+    {
+        return \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, $this->fdpBacktraceLimit);
+    }
+
+    /**
+     * Retrieve the fully qualified name of the ultimate parent class in the class hierarchy which contains this trait.
+     *
+     * @param array $backtrace Backtrace of the call triggering the `__set()`.
+     *
+     * @return string Class name or an empty string if the class name could not be determined.
+     */
+    private function fdpGetParentClass($backtrace)
+    {
+        if (
+            isset($backtrace[$this->fdpSetFrame]['class'], $backtrace[$this->fdpSetFrame]['function'])
+            && $backtrace[$this->fdpSetFrame]['function'] === '__set'
+        ) {
+            for ($class = $backtrace[$this->fdpSetFrame]['class']; ($parent = get_parent_class($class)) !== false; $class = $parent);
+            return $class;
         }
 
-        $backtraceNumber = 3;
-        $backtraceIndex = $backtraceNumber - 1;
+        // Parent could not be determined. Shouldn't be possible.
+        return ''; // @codeCoverageIgnore
+    }
 
-        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $backtraceNumber);
+    /**
+     * Retrieve the fully qualified name of the class containing the code which triggered the call to `__set()`.
+     *
+     * @param array $backtrace Backtrace of the call triggering the `__set()`.
+     *
+     * @return string Fully qualified class name or an empty string if the class name
+     *                could not be determined or the call was not made from a class context.
+     */
+    private function fdpGetCallOrigin($backtrace)
+    {
+        if (isset($backtrace[$this->fdpOriginFrame]['class'])) {
+            return $backtrace[$this->fdpOriginFrame]['class'];
+        }
 
-        if (!isset($backtrace[$backtraceIndex]) || !isset($backtrace[$backtraceIndex]['class'])) {
+        return '';
+    }
+
+    /**
+     * Set a property on the current object, but for a class which is not accessible
+     * from this trait, i.e. a `private` property in another class in the class hierarchy.
+     *
+     * @param string $targetClass  The class on which the property should to be set.
+     * @param string $propertyName Name of the property to set.
+     * @param mixed  $value        The new value for the property.
+     *
+     * @return bool Whether the property was succesfully set.
+     */
+    private function fdpSetInaccessibleProperty($targetClass, $propertyName, $value)
+    {
+        try {
+            $reflectionProp = new ReflectionProperty($targetClass, $propertyName);
+            $reflectionProp->setAccessible(true);
+            $reflectionProp->setValue($this, $value);
+            $reflectionProp->setAccessible(false);
+            return true;
+        } catch (ReflectionException $e) {
             return false;
         }
-
-        $class = $backtrace[$backtraceIndex]['class'];
-
-        return is_a(static::class, $class, true);
-    }
-
-    private function isPublicProperty($name)
-    {
-        return (new ReflectionProperty($this, $name))->isPublic();
-    }
-
-    private static function propertyExists($name)
-    {
-        $class = static::class;
-
-        do {
-            $exists = property_exists($class, $name);
-            if ($exists) {
-                return true;
-            }
-        } while ($class = get_parent_class($class));
-
-        return false;
     }
 }

--- a/src/ForbidDynamicProperties.php
+++ b/src/ForbidDynamicProperties.php
@@ -2,6 +2,7 @@
 
 namespace WpOrg\DynamicPropertiesUtils;
 
+use Error;
 use OutOfBoundsException;
 use ReflectionException;
 use ReflectionProperty;
@@ -60,6 +61,7 @@ trait ForbidDynamicProperties
      *
      * @return void
      *
+     * @throws Error                When an attempt is made to set an inaccessible property.
      * @throws OutOfBoundsException When an attempt is made to set a dynamic property.
      */
     public function __set($name, $value)
@@ -105,7 +107,7 @@ trait ForbidDynamicProperties
 
         if ($callOrigin !== static::class && \property_exists(static::class, $name) === true) {
             // This is an inaccessible property in the "outer" class. Emulate the PHP native error.
-            \trigger_error(\sprintf('Cannot access private property %s::$%s', static::class, $name), \E_USER_ERROR);
+            throw new Error(\sprintf('Cannot access private property %s::$%s', static::class, $name));
             return;
         }
 


### PR DESCRIPTION
### ForbidDynamicProperties: fix the bugs

This commit updates the proof of concept trait to a fully working trait.

The tests on PHP 7.2 - 8.2 now pass, but more work is still needed to make the code compatible with PHP < 7.2.

This is basically a full rewrite of the trait based on the ideas contained in the proof of concept.

It solves the following problems:
* Overreach of the original `propertyExists()` method, which reported `true` for `private` properties everywhere in the class hierarchy, while for `private` properties not accessible from the calling context, the `OutOfBounds` exception should be thrown (in most cases).
* Failure to set `private` properties on classes in the current class hierarchy, but not in the class containing the `trait`. Those will now be set using `Reflection`.
* Overreach when trying to set properties. Properties which PHP would report as inaccessible, should still be reported as such. To that effect, a `trigger_error()` call emulating the PHP native error has been added.

Note: While there are still some PHP < 7.2 hickups to smooth out, this should get us a lot closer to the intended behaviour.

Includes:
* Adding documentation to the trait in all the appropriate places.
* Adding a prefix to all properties in the `trait` to prevent potential conflicts wth properties declared in the class which composes-in the trait.
* Adding a prefix to all methods in the `trait`, with the exception of `__set()` (of course). This should minimize the risk of a class which uses the trait accidentally overloading one of the methods needed for the trait.


### ForbidDynamicProperties: emulate the PHP native "no access" error more closely

This fixes the test failures on PHP 7.0 and 7.1.

### ForbidDynamicProperties: minor tweaks

Thinking this over some more...
The helper methods in this class will also be needed by the `DeprecateDynamicProperties` trait and possibly by more magic method helper traits if added in the future.
Which means that in a future commit, they will probably be moved to a `DynamicPropertiesHelpers` trait which then will be `use`d by this trait.

With that in mind, I'm:
* Changing the property and method prefix from `fdp` (Forbidden Dynamic Properties) to `dpu` (Dynamic Properties Utils).
* Removing the method and property which stored the `ReflectionProperty` instance to make the `isPropertyPublic()` and `isPropertyProtected()` methods self-contained.

N.B.: This commit should be squashed into the first commit, but I didn't want to confuse potentially ongoing reviews..