### PR TITLE
Change namespace vendor to WordPress.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,12 @@
     },
     "autoload": {
         "psr-4": {
-            "WpOrg\\DynamicPropertiesUtils\\": "src/"
+            "WordPress\\DynamicPropertiesUtils\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "WpOrg\\DynamicPropertiesUtils\\Tests\\": "tests/"
+            "WordPress\\DynamicPropertiesUtils\\Tests\\": "tests/"
         }
     },
     "scripts": {

--- a/src/ForbidDynamicProperties.php
+++ b/src/ForbidDynamicProperties.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils;
+namespace WordPress\DynamicPropertiesUtils;
 
 use OutOfBoundsException;
 use ReflectionProperty;

--- a/tests/Fixtures/ForbidDynamicPropertiesChildClassFixture.php
+++ b/tests/Fixtures/ForbidDynamicPropertiesChildClassFixture.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
 class ForbidDynamicPropertiesChildClassFixture extends ForbidDynamicPropertiesParentClassFixture
 {

--- a/tests/Fixtures/ForbidDynamicPropertiesGrandchildClassFixture.php
+++ b/tests/Fixtures/ForbidDynamicPropertiesGrandchildClassFixture.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
 class ForbidDynamicPropertiesGrandchildClassFixture extends ForbidDynamicPropertiesChildClassFixture
 {

--- a/tests/Fixtures/ForbidDynamicPropertiesParentClassFixture.php
+++ b/tests/Fixtures/ForbidDynamicPropertiesParentClassFixture.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
-use WpOrg\DynamicPropertiesUtils\ForbidDynamicProperties;
+use WordPress\DynamicPropertiesUtils\ForbidDynamicProperties;
 
 class ForbidDynamicPropertiesParentClassFixture
 {

--- a/tests/Fixtures/ForbidDynamicPropertiesStandAloneClassFixture.php
+++ b/tests/Fixtures/ForbidDynamicPropertiesStandAloneClassFixture.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
-use WpOrg\DynamicPropertiesUtils\ForbidDynamicProperties;
+use WordPress\DynamicPropertiesUtils\ForbidDynamicProperties;
 
 class ForbidDynamicPropertiesStandAloneClassFixture
 {

--- a/tests/Fixtures/NonClassFunctionsFixture.php
+++ b/tests/Fixtures/NonClassFunctionsFixture.php
@@ -4,7 +4,7 @@
  * Fixture to test triggering the magic methods from outside any class context.
  */
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
 function testPropertyIssetFromFunction($objectInstance, $name)
 {

--- a/tests/Fixtures/PHPNativeChildClassFixture.php
+++ b/tests/Fixtures/PHPNativeChildClassFixture.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
 class PHPNativeChildClassFixture extends PHPNativeParentClassFixture
 {

--- a/tests/Fixtures/PHPNativeGrandchildClassFixture.php
+++ b/tests/Fixtures/PHPNativeGrandchildClassFixture.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
 class PHPNativeGrandchildClassFixture extends PHPNativeChildClassFixture
 {

--- a/tests/Fixtures/PHPNativeParentClassFixture.php
+++ b/tests/Fixtures/PHPNativeParentClassFixture.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
 class PHPNativeParentClassFixture
 {

--- a/tests/Fixtures/PHPNativeStandAloneClassFixture.php
+++ b/tests/Fixtures/PHPNativeStandAloneClassFixture.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
 class PHPNativeStandAloneClassFixture
 {

--- a/tests/Fixtures/StdclassChildClassFixture.php
+++ b/tests/Fixtures/StdclassChildClassFixture.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
 class StdclassChildClassFixture extends StdclassParentClassFixture
 {

--- a/tests/Fixtures/StdclassGrandchildClassFixture.php
+++ b/tests/Fixtures/StdclassGrandchildClassFixture.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
 class StdclassGrandchildClassFixture extends StdclassChildClassFixture
 {

--- a/tests/Fixtures/StdclassParentClassFixture.php
+++ b/tests/Fixtures/StdclassParentClassFixture.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
 use stdClass;
 

--- a/tests/Fixtures/StdclassStandAloneClassFixture.php
+++ b/tests/Fixtures/StdclassStandAloneClassFixture.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Fixtures;
+namespace WordPress\DynamicPropertiesUtils\Tests\Fixtures;
 
 use stdClass;
 

--- a/tests/Unit/ForbidDynamicProperties/ForbidDynamicPropertiesTestCase.php
+++ b/tests/Unit/ForbidDynamicProperties/ForbidDynamicPropertiesTestCase.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
+namespace WordPress\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
 
-use WpOrg\DynamicPropertiesUtils\Tests\Unit\TestCase;
+use WordPress\DynamicPropertiesUtils\Tests\Unit\TestCase;
 
 /**
  * ForbidDynamicProperties base test case.

--- a/tests/Unit/ForbidDynamicProperties/TestChildObjectAccessFromInsideChild.php
+++ b/tests/Unit/ForbidDynamicProperties/TestChildObjectAccessFromInsideChild.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
+namespace WordPress\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
 
 use OutOfBoundsException;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesChildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeChildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassChildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesChildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeChildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\StdclassChildClassFixture;
 
 /**
  * Verify the behaviour of the trait emulates the PHP native behaviour with the exception of
@@ -16,7 +16,7 @@ use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassChildClassFixture;
  * class structure with the object being a "child" and properties
  * existing in the parent and the child classes.
  *
- * @covers \WpOrg\DynamicPropertiesUtils\ForbidDynamicProperties
+ * @covers \WordPress\DynamicPropertiesUtils\ForbidDynamicProperties
  */
 final class TestChildObjectAccessFromInsideChild extends ForbidDynamicPropertiesTestCase
 {

--- a/tests/Unit/ForbidDynamicProperties/TestChildObjectAccessFromInsideParent.php
+++ b/tests/Unit/ForbidDynamicProperties/TestChildObjectAccessFromInsideParent.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
+namespace WordPress\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
 
 use OutOfBoundsException;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesChildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeChildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassChildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesChildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeChildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\StdclassChildClassFixture;
 
 /**
  * Verify the behaviour of the trait emulates the PHP native behaviour with the exception of
@@ -16,7 +16,7 @@ use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassChildClassFixture;
  * class structure with the object being a "child" and properties
  * existing in the parent and the child classes.
  *
- * @covers \WpOrg\DynamicPropertiesUtils\ForbidDynamicProperties
+ * @covers \WordPress\DynamicPropertiesUtils\ForbidDynamicProperties
  */
 final class TestChildObjectAccessFromInsideParent extends ForbidDynamicPropertiesTestCase
 {

--- a/tests/Unit/ForbidDynamicProperties/TestChildObjectAccessFromOutside.php
+++ b/tests/Unit/ForbidDynamicProperties/TestChildObjectAccessFromOutside.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
+namespace WordPress\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
 
 use OutOfBoundsException;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesChildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeChildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassChildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesChildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeChildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\StdclassChildClassFixture;
 
 /**
  * Verify the behaviour of the trait emulates the PHP native behaviour with the exception of
@@ -16,7 +16,7 @@ use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassChildClassFixture;
  * is part of a hierarchical class structure with the object being a "child" and properties
  * existing in the parent and the child classes.
  *
- * @covers \WpOrg\DynamicPropertiesUtils\ForbidDynamicProperties
+ * @covers \WordPress\DynamicPropertiesUtils\ForbidDynamicProperties
  */
 final class TestChildObjectAccessFromOutside extends ForbidDynamicPropertiesTestCase
 {

--- a/tests/Unit/ForbidDynamicProperties/TestGrandchildObjectAccessFromInsideChild.php
+++ b/tests/Unit/ForbidDynamicProperties/TestGrandchildObjectAccessFromInsideChild.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
+namespace WordPress\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
 
 use OutOfBoundsException;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesGrandchildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeGrandchildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassGrandchildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesGrandchildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeGrandchildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\StdclassGrandchildClassFixture;
 
 /**
  * Verify the behaviour of the trait emulates the PHP native behaviour with the exception of
@@ -16,7 +16,7 @@ use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassGrandchildClassFixture;
  * class structure with the object being a "grandchild" and properties
  * existing in the parent, child and the grandchild classes.
  *
- * @covers \WpOrg\DynamicPropertiesUtils\ForbidDynamicProperties
+ * @covers \WordPress\DynamicPropertiesUtils\ForbidDynamicProperties
  */
 final class TestGrandchildObjectAccessFromInsideChild extends ForbidDynamicPropertiesTestCase
 {

--- a/tests/Unit/ForbidDynamicProperties/TestGrandchildObjectAccessFromInsideGrandchild.php
+++ b/tests/Unit/ForbidDynamicProperties/TestGrandchildObjectAccessFromInsideGrandchild.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
+namespace WordPress\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
 
 use OutOfBoundsException;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesGrandchildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeGrandchildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassGrandchildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesGrandchildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeGrandchildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\StdclassGrandchildClassFixture;
 
 /**
  * Verify the behaviour of the trait emulates the PHP native behaviour with the exception of
@@ -16,7 +16,7 @@ use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassGrandchildClassFixture;
  * class structure with the object being a "grandchild" and properties
  * existing in the parent, child and the grandchild classes.
  *
- * @covers \WpOrg\DynamicPropertiesUtils\ForbidDynamicProperties
+ * @covers \WordPress\DynamicPropertiesUtils\ForbidDynamicProperties
  */
 final class TestGrandchildObjectAccessFromInsideGrandchild extends ForbidDynamicPropertiesTestCase
 {

--- a/tests/Unit/ForbidDynamicProperties/TestGrandchildObjectAccessFromInsideParent.php
+++ b/tests/Unit/ForbidDynamicProperties/TestGrandchildObjectAccessFromInsideParent.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
+namespace WordPress\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
 
 use OutOfBoundsException;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesGrandchildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeGrandchildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassGrandchildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesGrandchildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeGrandchildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\StdclassGrandchildClassFixture;
 
 /**
  * Verify the behaviour of the trait emulates the PHP native behaviour with the exception of
@@ -16,7 +16,7 @@ use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassGrandchildClassFixture;
  * class structure with the object being a "grandchild" and properties
  * existing in the parent, child and the grandchild classes.
  *
- * @covers \WpOrg\DynamicPropertiesUtils\ForbidDynamicProperties
+ * @covers \WordPress\DynamicPropertiesUtils\ForbidDynamicProperties
  */
 final class TestGrandchildObjectAccessFromInsideParent extends ForbidDynamicPropertiesTestCase
 {

--- a/tests/Unit/ForbidDynamicProperties/TestGrandchildObjectAccessFromOutside.php
+++ b/tests/Unit/ForbidDynamicProperties/TestGrandchildObjectAccessFromOutside.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
+namespace WordPress\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
 
 use OutOfBoundsException;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesGrandchildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeGrandchildClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassGrandchildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesGrandchildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeGrandchildClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\StdclassGrandchildClassFixture;
 
 /**
  * Verify the behaviour of the trait emulates the PHP native behaviour with the exception of
@@ -16,7 +16,7 @@ use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassGrandchildClassFixture;
  * is part of a hierarchical class structure with the object being a "grandchild" and properties
  * existing in the parent, child and the grandchild classes.
  *
- * @covers \WpOrg\DynamicPropertiesUtils\ForbidDynamicProperties
+ * @covers \WordPress\DynamicPropertiesUtils\ForbidDynamicProperties
  */
 final class TestGrandchildObjectAccessFromOutside extends ForbidDynamicPropertiesTestCase
 {

--- a/tests/Unit/ForbidDynamicProperties/TestStandAloneClassAccessFromFunctionOutside.php
+++ b/tests/Unit/ForbidDynamicProperties/TestStandAloneClassAccessFromFunctionOutside.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
+namespace WordPress\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
 
 use OutOfBoundsException;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesStandAloneClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeStandAloneClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassStandAloneClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesStandAloneClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeStandAloneClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\StdclassStandAloneClassFixture;
 
-use function WpOrg\DynamicPropertiesUtils\Tests\Fixtures\testPropertyAccessFromFunction;
-use function WpOrg\DynamicPropertiesUtils\Tests\Fixtures\testPropertyIssetFromFunction;
-use function WpOrg\DynamicPropertiesUtils\Tests\Fixtures\testPropertyModificationFromFunction;
-use function WpOrg\DynamicPropertiesUtils\Tests\Fixtures\testPropertyUnsetFromFunction;
+use function WordPress\DynamicPropertiesUtils\Tests\Fixtures\testPropertyAccessFromFunction;
+use function WordPress\DynamicPropertiesUtils\Tests\Fixtures\testPropertyIssetFromFunction;
+use function WordPress\DynamicPropertiesUtils\Tests\Fixtures\testPropertyModificationFromFunction;
+use function WordPress\DynamicPropertiesUtils\Tests\Fixtures\testPropertyUnsetFromFunction;
 
 /**
  * Verify the behaviour of the trait emulates the PHP native behaviour with the exception of
@@ -19,7 +19,7 @@ use function WpOrg\DynamicPropertiesUtils\Tests\Fixtures\testPropertyUnsetFromFu
  * This test class specifically tests the behaviour when accessing/modifying a property from
  * inside a function outside the context of the class containing the property.
  *
- * @covers \WpOrg\DynamicPropertiesUtils\ForbidDynamicProperties
+ * @covers \WordPress\DynamicPropertiesUtils\ForbidDynamicProperties
  */
 final class TestStandAloneClassAccessFromFunctionOutside extends ForbidDynamicPropertiesTestCase
 {

--- a/tests/Unit/ForbidDynamicProperties/TestStandAloneClassAccessFromInside.php
+++ b/tests/Unit/ForbidDynamicProperties/TestStandAloneClassAccessFromInside.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
+namespace WordPress\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
 
 use OutOfBoundsException;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesStandAloneClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeStandAloneClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassStandAloneClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesStandAloneClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeStandAloneClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\StdclassStandAloneClassFixture;
 
 /**
  * Verify the behaviour of the trait emulates the PHP native behaviour with the exception of
@@ -14,7 +14,7 @@ use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassStandAloneClassFixture;
  * This test class specifically tests the behaviour when accessing/modifying a property from
  * inside the context of the class containing the property.
  *
- * @covers \WpOrg\DynamicPropertiesUtils\ForbidDynamicProperties
+ * @covers \WordPress\DynamicPropertiesUtils\ForbidDynamicProperties
  */
 final class TestStandAloneClassAccessFromInside extends ForbidDynamicPropertiesTestCase
 {

--- a/tests/Unit/ForbidDynamicProperties/TestStandAloneClassAccessFromOutside.php
+++ b/tests/Unit/ForbidDynamicProperties/TestStandAloneClassAccessFromOutside.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
+namespace WordPress\DynamicPropertiesUtils\Tests\Unit\ForbidDynamicProperties;
 
 use OutOfBoundsException;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesStandAloneClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeStandAloneClassFixture;
-use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassStandAloneClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\ForbidDynamicPropertiesStandAloneClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\PHPNativeStandAloneClassFixture;
+use WordPress\DynamicPropertiesUtils\Tests\Fixtures\StdclassStandAloneClassFixture;
 
 /**
  * Verify the behaviour of the trait emulates the PHP native behaviour with the exception of
@@ -14,7 +14,7 @@ use WpOrg\DynamicPropertiesUtils\Tests\Fixtures\StdclassStandAloneClassFixture;
  * This test class specifically tests the behaviour when accessing/modifying a property from
  * outside the context of the class containing the property.
  *
- * @covers \WpOrg\DynamicPropertiesUtils\ForbidDynamicProperties
+ * @covers \WordPress\DynamicPropertiesUtils\ForbidDynamicProperties
  */
 final class TestStandAloneClassAccessFromOutside extends ForbidDynamicPropertiesTestCase
 {

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WpOrg\DynamicPropertiesUtils\Tests\Unit;
+namespace WordPress\DynamicPropertiesUtils\Tests\Unit;
 
 use Error;
 use PHPUnit\Runner\Version as PHPUnit_Version;


### PR DESCRIPTION
This changes the vendor portion of the namespace from `WpOrg` to `WordPress`.

As mentioned in the upgrade to Requests 2.0, there was some concern about the use of WpOrg instead of WordPress as the vendor portion of the namespace. See @dd32's [comment](https://core.trac.wordpress.org/ticket/54504#comment:8), and @SergeyBiryukov's [comment](https://core.trac.wordpress.org/ticket/54504#comment:9) as the start of the discussion followed by several comments.

I agreed with this at the time but didn't feel the need to join the discussion.

